### PR TITLE
Updated the broken links to BDD wiki

### DIFF
--- a/site-frontend/src/site/content/introduction.html
+++ b/site-frontend/src/site/content/introduction.html
@@ -15,8 +15,7 @@ behaviour-based.  It positions itself as a <b>development paradigm</b>, emphasis
 
 <p>In BDD, the behaviours represent both the specification and the test cases.</p>
 
-<p>You can find out more about Behaviour-Driven Development on the <a href="http://behaviour-driven.org">BDD wiki</a>, or in the article 
-<a href="http://behaviour-driven.org/Introduction">Introducing BDD</a>.</p>
+<p>You can find out more about Behaviour-Driven Development on the <a href="https://en.wikipedia.org/wiki/Behavior-driven_development">BDD wiki</a>.</p>
 
 <h2>Getting Started</h2>
 


### PR DESCRIPTION
Hello,

The link to an external wiki page about BDD seems to be broken as the target website do not contain any relevant webpage about BDD. This may cause confusion to the newbies who are learning this topic newly.

Hence, corrected the external links by updating the link to the official Wikipedia definition of BDD.

Kindly approve the Pull request.